### PR TITLE
terme: parse ^? as backspace.

### DIFF
--- a/src/terme_prompt.c
+++ b/src/terme_prompt.c
@@ -268,6 +268,10 @@ static int terme_readline_control_(Execute ptr,
 			Return(terme_readline_ctrl_z_(str));
 			break;
 
+		case 0x7F:  /* DEL, backspace */
+			str->type = terme_escape_backspace;
+			break;
+
 		default:
 			str->type = terme_escape_ignore;
 			break;


### PR DESCRIPTION
This is used by most terminal emulators that don't use ^H; for
simplicity just parse both control sequences as backspace.

Fixes backspacing on urxvt and gnome-terminal.