### PR TITLE
Fix include path typo

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,7 @@ include src/release.mk
 endif
 
 CFLAGS += $(lisp_optimize)
-CFLAGS += -I/usr/incldue -I/usr/local/include
+CFLAGS += -I/usr/include -I/usr/local/include
 LDFLAGS += -L/usr/lib -L/usr/local/lib
 VPATH = src:test
 bin_PROGRAMS = npt


### PR DESCRIPTION
it said /usr/incldue, i've changed it to /usr/include

i think it was a typo but i don't know your computer